### PR TITLE
Stop shipping javac with fiji

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -710,11 +710,6 @@
 		</dependency>
 		<dependency>
 			<groupId>sc.fiji</groupId>
-			<artifactId>javac</artifactId>
-			<scope>runtime</scope>
-		</dependency>
-		<dependency>
-			<groupId>sc.fiji</groupId>
 			<artifactId>legacy-imglib1</artifactId>
 			<scope>runtime</scope>
 		</dependency>


### PR DESCRIPTION
This was Fiji's fork of OpenJDK javac 1.6.0_24. We do not currently
have a fork of 1.8.x, nor do I want to create/maintain one.

Simpler is to simply let users install their own JDK, and then point
Fiji at it. Users who do not need javac don't have to download it.
And there is no more technical maintenance, nor potential legal issues.

See also this issue:
  https://github.com/imagej/imagej/issues/105